### PR TITLE
Move translator comment closer to string.

### DIFF
--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -20,8 +20,8 @@
 
 	<div class="entry-content">
 		<?php
-			/* translators: %s: Name of current post */
 			the_content( sprintf(
+				/* translators: %s: Name of current post. */
 				wp_kses( __( 'Continue reading %s <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			) );


### PR DESCRIPTION
Translator comments should be placed directly in the line above the string to be translated, in order for parser to pick it up.